### PR TITLE
17291 links are ownable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source 'https://rubygems.org'
 
+gem 'annotate'
 gem 'base32-crockford'
 gem 'bootsnap'
 gem 'dotenv-rails'
@@ -13,12 +14,13 @@ gem 'rails', '~> 6.0.0'
 gem 'webpacker'
 gem 'will_paginate'
 
-# assets
-gem 'coffee-rails'
-gem 'sass-rails'
-# See https://github.com/sstephenson/execjs#readme for more supported runtimes
-gem 'therubyracer'
-gem 'uglifier'
+group :assets do
+  gem 'coffee-rails'
+  gem 'sass-rails'
+  # See https://github.com/sstephenson/execjs#readme for more supported runtimes
+  gem 'therubyracer'
+  gem 'uglifier'
+end
 
 group :development do
   gem 'listen'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,9 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    annotate (3.1.1)
+      activerecord (>= 3.2, < 7.0)
+      rake (>= 10.4, < 14.0)
     ast (2.4.1)
     base32-crockford (0.1.0)
     bindex (0.8.1)
@@ -256,6 +259,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  annotate
   base32-crockford
   bootsnap
   byebug

--- a/app/models/url.rb
+++ b/app/models/url.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: urls
+#
+#  id         :integer          not null, primary key
+#  auto       :boolean          default(TRUE)
+#  clicks     :integer          default(0)
+#  shortened  :string(255)
+#  to         :string(10240)    not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :integer
+#
+# Indexes
+#
+#  index_urls_on_auto       (auto)
+#  index_urls_on_shortened  (shortened)
+#  index_urls_on_to         (to)
+#  index_urls_on_user_id    (user_id)
+#
 class Url < ApplicationRecord
   include ActiveModel::Validations
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,22 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: users
+#
+#  id         :integer          not null, primary key
+#  email      :string(100)
+#  superadmin :boolean          default(FALSE)
+#  username   :string(100)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email       (email)
+#  index_users_on_superadmin  (superadmin)
+#  index_users_on_username    (username)
+#
 require 'berkman_ldap_auth_mixin'
 
 class User < ApplicationRecord

--- a/lib/berkman_ldap_auth.rb
+++ b/lib/berkman_ldap_auth.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 module BerkmanLdapAuth
-  gem 'net-ldap'
-  require 'net/ldap'
-  require 'yaml'
-
   # See the Brief Introduction to LDAP in the Net::LDAP docs:
   # https://www.rubydoc.info/gems/ruby-net-ldap/Net/LDAP
   def self.authenticate(username, password)

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'active_admin'                => 'false',
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'before',
+      'position_in_class'           => 'before',
+      'position_in_test'            => 'before',
+      'position_in_fixture'         => 'before',
+      'position_in_factory'         => 'before',
+      'position_in_serializer'      => 'before',
+      'show_foreign_keys'           => 'true',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'true',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'false',
+      'exclude_fixtures'            => 'false',
+      'exclude_factories'           => 'false',
+      'exclude_serializers'         => 'false',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'false',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_yard'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'true',
+      'trace'                       => 'false',
+      'wrapper_open'                => nil,
+      'wrapper_close'               => nil,
+      'with_comment'                => 'true'
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/test/fixtures/urls.yml
+++ b/test/fixtures/urls.yml
@@ -1,4 +1,23 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/Fixtures.html
+# == Schema Information
+#
+# Table name: urls
+#
+#  id         :integer          not null, primary key
+#  auto       :boolean          default(TRUE)
+#  clicks     :integer          default(0)
+#  shortened  :string(255)
+#  to         :string(10240)    not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :integer
+#
+# Indexes
+#
+#  index_urls_on_auto       (auto)
+#  index_urls_on_shortened  (shortened)
+#  index_urls_on_to         (to)
+#  index_urls_on_user_id    (user_id)
+#
 
 normalpublic:
   id: 1

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,4 +1,20 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/Fixtures.html
+# == Schema Information
+#
+# Table name: users
+#
+#  id         :integer          not null, primary key
+#  email      :string(100)
+#  superadmin :boolean          default(FALSE)
+#  username   :string(100)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email       (email)
+#  index_users_on_superadmin  (superadmin)
+#  index_users_on_username    (username)
+#
 
 normal:
   id: 1

--- a/test/integration/urls_test.rb
+++ b/test/integration/urls_test.rb
@@ -67,4 +67,14 @@ class UrlsTest < IntegrationTest
     assert page.has_no_content?('https://totallydifferent.domain.com')
     assert page.current_path == search_urls_path
   end
+
+  it 'adds users to urls automatically on url creation' do
+    visit urls_path
+    fill_in 'URL to shorten', with: 'https://a.new.url'
+    click_on 'Shorten'
+
+    current_user = User.find_by(username: USERNAME)
+
+    assert Url.last.user == current_user
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,8 +35,10 @@ class IntegrationTest < MiniTest::Spec
 
   ActiveRecord::FixtureSet.create_fixtures('test/fixtures', %w[urls users])
 
+  USERNAME = 'username'
+
   def authorize
     visit '/'
-    page.driver.browser.authorize('username', 'password')
+    page.driver.browser.authorize(USERNAME, 'password')
   end
 end

--- a/test/unit/url_test.rb
+++ b/test/unit/url_test.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: urls
+#
+#  id         :integer          not null, primary key
+#  auto       :boolean          default(TRUE)
+#  clicks     :integer          default(0)
+#  shortened  :string(255)
+#  to         :string(10240)    not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :integer
+#
+# Indexes
+#
+#  index_urls_on_auto       (auto)
+#  index_urls_on_shortened  (shortened)
+#  index_urls_on_to         (to)
+#  index_urls_on_user_id    (user_id)
+#
 require 'test_helper'
 
 describe Url do


### PR DESCRIPTION
https://cyber.harvard.edu/projectmanagement/issues/17291

It turns out we already had the desired functionality; we just didn't test for it. Now we do!

Retaining the `optional: true` on `Url` because most of our production urls are unowned, and it's not obvious to whom to assign them.